### PR TITLE
Changed REST routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,14 +5,14 @@ database.
 
 You can build and run the project with [stack](http://haskellstack.org/), e.g.:
 
-``` bash
+```shell
 stack build
 stack exec example-servant-persistent
 ```
 
 Then you can query the server from a separate shell:
 
-``` bash
-curl -H 'Content-type: application/json' localhost:3000/user/add --data '{"name": "Alice", "age": 42}'
-curl -H 'Content-type: application/json' localhost:3000/user/get/Alice
+```shell
+curl -H 'Content-type: application/json' localhost:3000/user --data '{"name": "Alice", "age": 42}'
+curl -H 'Content-type: application/json' localhost:3000/user/Alice
 ```

--- a/src/Api.hs
+++ b/src/Api.hs
@@ -18,8 +18,8 @@ import Servant.API
 
 
 type Api =
-       "user" :> "add" :> ReqBody '[JSON] User :> Post '[JSON] (Maybe (Key User))
-  :<|> "user" :> "get" :> Capture "name" Text  :> Get  '[JSON] (Maybe User)
+       "user" :> ReqBody '[JSON] User :> Post '[JSON] (Maybe (Key User))
+  :<|> "user" :> Capture "name" Text  :> Get  '[JSON] (Maybe User)
 
 api :: Proxy Api
 api = Proxy

--- a/test/AppSpec.hs
+++ b/test/AppSpec.hs
@@ -28,11 +28,11 @@ userAdd :<|> userGet = client api
 spec :: Spec
 spec = do
   around withApp $ do
-    describe "/user/get" $ do
+    describe "/user GET" $ do
       it "returns Nothing for non-existing users" $ \ port -> do
         try port (userGet "foo") `shouldReturn` Nothing
 
-    describe "/user/add" $ do
+    describe "/user POST" $ do
       it "allows to add a user" $ \ port -> do
         let user = User "Alice" 1
         id <- try port (userAdd user)


### PR DESCRIPTION
I saw the example REST API has uncommon routes: `POST /user/add` and `GET /user/get/<name>`. The information that a new user entity is created or should be retrieved is encoded in the used HTTP method. Therefore I'd suggest removing it from the path because of redundancy.

The PR changes it to the expected interface:
* `POST /user`
* `GET /user/<name>`

Happy to hear your feadback and if this change is welcome 😃 